### PR TITLE
Enclose the filename in quotes; otherwise the shell fails on filename…

### DIFF
--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -175,8 +175,8 @@ EXECUTABLE is the full path to an eslint_d executable."
          (zerop (call-process-shell-command
                  (concat
                   executable
-                  " --print-config "
-                  filename))))))
+                  " --print-config \""
+                  filename "\""))))))
 
 (defun eslintd-fix--deactivate (message)
   "Deactivate ‘eslintd-fix-mode’ and show MESSAGE explaining why."

--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -175,8 +175,8 @@ EXECUTABLE is the full path to an eslint_d executable."
          (zerop (call-process-shell-command
                  (concat
                   executable
-                  " --print-config \""
-                  filename "\""))))))
+                  " --print-config "
+                  (shell-quote-argument filename)))))))
 
 (defun eslintd-fix--deactivate (message)
   "Deactivate ‘eslintd-fix-mode’ and show MESSAGE explaining why."


### PR DESCRIPTION
At least with Fish shell, if the js filename includes spaces, eslintd-fix call to the eslint_d binary will fail unless we enclose it in quotation marks. Would you please check if this fix doesn't break eslintd-fix for other shells? Thank you.