### PR TITLE
Used call-proccess to check for compatible version.

### DIFF
--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -164,7 +164,9 @@ size by applying the changes as a diff patch."
   (and (file-executable-p executable)
        (string-match-p
         "--fix-to-stdout"
-        (or (shell-command-to-string (concat executable " --help")) ""))))
+        (condition-case nil
+            (with-output-to-string (call-process executable nil standard-output nil "--help"))
+          (error "")))))
 
 (defun eslintd-fix--eslint-config-foundp (executable)
   "Return t if there is an eslint config for the current file.


### PR DESCRIPTION
Hi, I'm using `nix` and `direnv` to setup development environment. `shell-command-to-string` can not find correct `node` binary for me. I guess it's due to the fact that new shell is started and env vars are not set by `direnv`. I tried to change `shell-file-name` variable to point to correct shell with no luck. However docs for `shell-command` state that `call-process` often serves better. Because it does not start new shell. So I changed `eslintd-fix--compatible-versionp` function to use `call-process` instead of `shell-command-to-string`. It works in the same way and even faster.