### PR TITLE
Fix default portfile location

### DIFF
--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -40,6 +40,7 @@
 
 ;;; Code:
 (require 'dash)
+(require 'xdg) ; for `xdg-runtime-dir'
 
 (defgroup eslintd-fix nil
   "Fix javascript code with eslint_d"
@@ -55,7 +56,9 @@
   :group 'eslintd-fix
   :type 'string)
 
-(defcustom eslintd-fix-portfile "~/.eslint_d"
+(defcustom eslintd-fix-portfile
+  (let ((directory (or (xdg-runtime-dir) "~/")))
+    (expand-file-name ".eslint_d" directory))
   "The file written by eslint_d containing the port and token."
   :group 'eslintd-fix
   :type 'string)

--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -5,7 +5,7 @@
 ;; Author: Aaron Jensen <aaronjensen@gmail.com>
 ;; URL: https://github.com/aaronjensen/eslintd-fix
 ;; Version: 1.1.0
-;; Package-Requires: ((dash "2.12.0") (emacs "24.3"))
+;; Package-Requires: ((dash "2.12.0") (emacs "26.3"))
 
 ;;; Commentary:
 


### PR DESCRIPTION
eslint_d changed the location of the `.eslint_d` file that eslintd-fix uses to connect to the server. See https://github.com/mantoni/eslint_d.js/issues/166#issuecomment-838374082.