### PR TITLE
Display message if eslint_d does not output within `eslintd-fix-timeout-seconds`

### DIFF
--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -287,11 +287,10 @@ Return t if the connection closes successfully."
       (if (eq (process-status connection) 'open)
           (accept-process-output connection 0.01 nil t)
         (throw 'done (eq (process-status connection) 'closed))))
-    (progn
-      (message
-       (concat "eslintd-fix: Did not receive any output in time."
-               "Try increasing custom variables `eslintd-fix-timeout-seconds` value."))
-      nil)))
+    (message
+     (concat "eslintd-fix: Timed out waiting for output, "
+             "try increasing eslintd-fix-timeout-seconds."))
+    nil))
 
 (defun eslintd-fix--get-connection ()
   "Return an open connection to eslint_d.

--- a/eslintd-fix.el
+++ b/eslintd-fix.el
@@ -287,7 +287,11 @@ Return t if the connection closes successfully."
       (if (eq (process-status connection) 'open)
           (accept-process-output connection 0.01 nil t)
         (throw 'done (eq (process-status connection) 'closed))))
-    nil))
+    (progn
+      (message
+       (concat "eslintd-fix: Did not receive any output in time."
+               "Try increasing custom variables `eslintd-fix-timeout-seconds` value."))
+      nil)))
 
 (defun eslintd-fix--get-connection ()
   "Return an open connection to eslint_d.


### PR DESCRIPTION
For a fix to be easier spotted, if user has an eslint configuration that runs longer than the default two seconds, e.g. with `eslint-plugin-tsc` enabled.